### PR TITLE
Add support for the non-standard ALIAS record

### DIFF
--- a/blockstack_zones/configs.py
+++ b/blockstack_zones/configs.py
@@ -1,6 +1,6 @@
 SUPPORTED_RECORDS = [
-    '$ORIGIN', '$TTL', 'SOA', 'NS', 'A', 'AAAA', 'CNAME', 'MX', 'PTR', 'TXT',
-    'SRV', 'SPF', 'URI'
+    '$ORIGIN', '$TTL', 'SOA', 'NS', 'A', 'AAAA', 'CNAME', 'ALIAS', 'MX',
+    'PTR', 'TXT', 'SRV', 'SPF', 'URI',
 ]
 
 DEFAULT_TEMPLATE = """
@@ -18,6 +18,8 @@ DEFAULT_TEMPLATE = """
 {aaaa}\n\
 \n\
 {cname}\n\
+\n\
+{alias}\n\
 \n\
 {ptr}\n\
 \n\

--- a/blockstack_zones/make_zone_file.py
+++ b/blockstack_zones/make_zone_file.py
@@ -1,7 +1,7 @@
 from .record_processors import (
     process_origin, process_ttl, process_soa, process_ns, process_a,
-    process_aaaa, process_cname, process_mx, process_ptr, process_txt,
-    process_srv, process_spf, process_uri
+    process_aaaa, process_cname, process_alias, process_mx, process_ptr,
+    process_txt, process_srv, process_spf, process_uri
 )
 from .configs import DEFAULT_TEMPLATE
 import copy
@@ -20,6 +20,7 @@ def make_zone_file(json_zone_file_input, origin=None, ttl=None, template=None):
         "a":       [ a records ],
         "aaaa":    [ aaaa records ]
         "cname":   [ cname records ]
+        "alias":   [ alias records ]
         "mx":      [ mx records ]
         "ptr":     [ ptr records ]
         "txt":     [ txt records ]
@@ -50,6 +51,7 @@ def make_zone_file(json_zone_file_input, origin=None, ttl=None, template=None):
     zone_file = process_a(json_zone_file.get('a', None), zone_file)
     zone_file = process_aaaa(json_zone_file.get('aaaa', None), zone_file)
     zone_file = process_cname(json_zone_file.get('cname', None), zone_file)
+    zone_file = process_alias(json_zone_file.get('alias', None), zone_file)
     zone_file = process_mx(json_zone_file.get('mx', None), zone_file)
     zone_file = process_ptr(json_zone_file.get('ptr', None), zone_file)
     zone_file = process_txt(json_zone_file.get('txt', None), zone_file)

--- a/blockstack_zones/parse_zone_file.py
+++ b/blockstack_zones/parse_zone_file.py
@@ -70,6 +70,7 @@ def make_parser():
     make_rr_subparser(subparsers, "A", [("ip", str)])
     make_rr_subparser(subparsers, "AAAA", [("ip", str)])
     make_rr_subparser(subparsers, "CNAME", [("alias", str)])
+    make_rr_subparser(subparsers, "ALIAS", [("host", str)])
     make_rr_subparser(subparsers, "MX", [("preference", str), ("host", str)])
     make_rr_subparser(subparsers, "TXT", [("txt", str)])
     make_rr_subparser(subparsers, "PTR", [("host", str)])

--- a/blockstack_zones/record_processors.py
+++ b/blockstack_zones/record_processors.py
@@ -152,6 +152,13 @@ def process_cname(data, template):
     return process_rr(data, "CNAME", "alias", "{cname}", template)
 
 
+def process_alias(data, template):
+    """
+    Replace {alias} in template with the serialized ALIAS records
+    """
+    return process_rr(data, "ALIAS", "host", "{alias}", template)
+
+
 def process_mx(data, template):
     """
     Replace {mx} in template with the serialized MX records

--- a/test_sample_data.py
+++ b/test_sample_data.py
@@ -9,6 +9,7 @@ pop 10800 IN CNAME access.mail.gandi.net.
 smtp 10800 IN CNAME relay.mail.gandi.net.
 webmail 10800 IN CNAME webmail.gandi.net.
 www 10800 IN CNAME webredir.vip.gandi.net.
+aname 10800 IN ALIAS otherdomain.com.
 @ 10800 IN MX 50 fb.mail.gandi.net.
 @ 10800 IN MX 10 spool.mail.gandi.net.""",
     "sample_2": """
@@ -23,7 +24,9 @@ dns2         IN     A       10.0.1.3
 ftp          IN     CNAME   server1
 mail         IN     CNAME   server1
 mail2        IN     CNAME   server2
-www          IN     CNAME   server2""",
+www          IN     CNAME   server2
+
+aname        IN     ALIAS   otherdomain.com""",
     "sample_3": """$ORIGIN example.com
 $TTL 86400
 @     IN     SOA    dns1.example.com.     hostmaster.example.com. (
@@ -49,7 +52,9 @@ dns2         IN     A       10.0.1.3
 ftp          IN     CNAME   server1
 mail         IN     CNAME   server1
 mail2        IN     CNAME   server2
-www          IN     CNAME   server2"""
+www          IN     CNAME   server2
+
+aname        IN     ALIAS   otherdomain.com"""
 }
 
 zone_file_objects = {
@@ -93,6 +98,9 @@ zone_file_objects = {
         { "name": "mail1", "alias": "mail" },
         { "name": "mail2", "alias": "mail" }
     ],
+    "alias":[
+        { "name": "aname", "host": "otherdomain.com"}
+    ],
     "mx": [
         { "preference": 0, "host": "mail1" },
         { "preference": 10, "host": "mail2" }
@@ -134,6 +142,9 @@ zone_file_objects = {
     "cname":[
         { "name": "mail1", "alias": "mail" },
         { "name": "mail2", "alias": "mail" }
+    ],
+    "alias":[
+        { "name": "aname", "host": "otherdomain.com"}
     ],
     "mx":[
         { "preference": 0, "host": "mail1" },

--- a/tests/zonefile_forward.json
+++ b/tests/zonefile_forward.json
@@ -27,6 +27,9 @@
         { "name": "mail1", "alias": "mail" },
         { "name": "mail2", "alias": "mail" }
     ],
+    "ALIAS":[
+        { "name": "aname", "alias": "otherdomain.com"}
+    ],
     "MX":[
         { "preference": 0, "host": "mail1" },
         { "preference": 10, "host": "mail2" }

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -45,6 +45,7 @@ class ZoneFileTests(unittest.TestCase):
         self.assertTrue(isinstance(zone_file, dict))
         self.assertTrue("a" in zone_file)
         self.assertTrue("cname" in zone_file)
+        self.assertTrue("alias" in zone_file)
         self.assertTrue("mx" in zone_file)
         self.assertTrue("$ttl" in zone_file)
         self.assertTrue("$origin" in zone_file)
@@ -55,6 +56,7 @@ class ZoneFileTests(unittest.TestCase):
         self.assertTrue(isinstance(zone_file, dict))
         self.assertTrue("a" in zone_file)
         self.assertTrue("cname" in zone_file)
+        self.assertTrue("alias" in zone_file)
         self.assertTrue("$ttl" in zone_file)
         self.assertTrue("$origin" in zone_file)
 
@@ -67,6 +69,7 @@ class ZoneFileTests(unittest.TestCase):
         self.assertTrue("ns" in zone_file)
         self.assertTrue("a" in zone_file)
         self.assertTrue("cname" in zone_file)
+        self.assertTrue("alias" in zone_file)
         self.assertTrue("$ttl" in zone_file)
         self.assertTrue("$origin" in zone_file)
 


### PR DESCRIPTION
I am using a DNS provider which supports create non-standard ALIAS records and would like to be able to generate and parse them with your library. I see that you already support the non-standard URL record.

Do you have any problems with adding this record to your library?
