### PR TITLE
Fix casing on dict lookup for PTR records

### DIFF
--- a/blockstack_zones/parse_zone_file.py
+++ b/blockstack_zones/parse_zone_file.py
@@ -324,7 +324,7 @@ def parse_line(parser, record_token, parsed_records):
         if record_dict[field] is None:
             del record_dict[field]
 
-    current_origin = record_dict.get('$ORIGIN', parsed_records.get('$ORIGIN', None))
+    current_origin = record_dict.get('$origin', parsed_records.get('$origin', None))
 
     # special record-specific fix-ups
     if record_type == 'PTR':


### PR DESCRIPTION
PTR records were failing to parse for me because the dict lookup for origin returned None.  The origin was in fact there, but the dict key was lower-case, not upper-case.  I'd love to get this fixed published out so it can be pip installed.  Thanks!
