### PR TITLE
Multiple string support for TXT records

### DIFF
--- a/blockstack_zones/parse_zone_file.py
+++ b/blockstack_zones/parse_zone_file.py
@@ -38,11 +38,23 @@ def make_rr_subparser(subparsers, rec_type, args_and_types):
     sp.add_argument("ttl", type=int, nargs='?')
     sp.add_argument(rec_type, type=str)
 
-    for (argname, argtype) in args_and_types:
-        sp.add_argument(argname, type=argtype)
-
+    for my_spec in args_and_types:
+        (argname, argtype) = my_spec[:2]
+        if len(my_spec) > 2:
+            nargs = my_spec[2]
+            sp.add_argument(argname, type=argtype, nargs=nargs)
+        else:
+            sp.add_argument(argname, type=argtype)
     return sp
 
+def make_txt_subparser(subparsers):
+    sp = subparsers.add_parser("TXT")
+
+    sp.add_argument("name", type=str)
+    sp.add_argument("--ttl", type=int)
+    sp.add_argument("TXT", type=str)
+    sp.add_argument("txt", type=str, nargs='+')
+    return sp
 
 def make_parser():
     """
@@ -71,7 +83,7 @@ def make_parser():
     make_rr_subparser(subparsers, "AAAA", [("ip", str)])
     make_rr_subparser(subparsers, "CNAME", [("alias", str)])
     make_rr_subparser(subparsers, "MX", [("preference", str), ("host", str)])
-    make_rr_subparser(subparsers, "TXT", [("txt", str)])
+    make_txt_subparser(subparsers)
     make_rr_subparser(subparsers, "PTR", [("host", str)])
     make_rr_subparser(subparsers, "SRV", [("priority", int), ("weight", int), ("port", int), ("target", str)])
     make_rr_subparser(subparsers, "SPF", [("data", str)])
@@ -298,15 +310,20 @@ def parse_line(parser, record_token, parsed_records):
     elif len(record_token) >= 3 and record_token[2] in SUPPORTED_RECORDS:
         # with ttl
         record_token = [record_token[2]] + record_token
-
+        if record_token[0] == "TXT":
+            record_token = record_token[:2] + ["--ttl"] + record_token[2:]
     try:
         rr, unmatched = parser.parse_known_args(record_token)
         assert len(unmatched) == 0, "Unmatched fields: %s" % unmatched
     except (SystemExit, AssertionError, InvalidLineException):
+        import traceback
+        traceback.print_exc()
         # invalid argument 
         raise InvalidLineException(line)
 
     record_dict = rr.__dict__
+    if record_token[0] == "TXT" and len(record_dict['txt']) == 1:
+        record_dict['txt'] = record_dict['txt'][0]
 
     # what kind of record? including origin and ttl
     record_type = None

--- a/blockstack_zones/record_processors.py
+++ b/blockstack_zones/record_processors.py
@@ -170,9 +170,18 @@ def process_txt(data, template):
     """
     Replace {txt} in template with the serialized TXT records
     """
-    # quote txt
-    data_dup = quote_field(data, "txt")
-    return process_rr(data_dup, "TXT", "txt", "{txt}", template)
+    if data is None:
+        to_process = None
+    else:
+        # quote txt
+        to_process = copy.deepcopy(data)
+        for datum in to_process:
+            if isinstance(datum["txt"], list):
+                datum["txt"] = " ".join(['"%s"' % entry.replace(";", "\;")
+                                         for entry in datum["txt"]])
+            else:
+                datum["txt"] = '"%s"' % datum["txt"].replace(";", "\;")
+    return process_rr(to_process, "TXT", "txt", "{txt}", template)
 
 
 def process_srv(data, template):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='blockstack-zones',
-    version='0.14.1',
+    version='0.15.0',
     url='https://github.com/blockstack/dns-zone-file-py',
     license='MIT',
     author='Blockstack Developers',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='blockstack-zones',
-    version='0.15.0',
+    version='0.14.3',
     url='https://github.com/blockstack/dns-zone-file-py',
     license='MIT',
     author='Blockstack Developers',

--- a/test_sample_data.py
+++ b/test_sample_data.py
@@ -49,7 +49,40 @@ dns2         IN     A       10.0.1.3
 ftp          IN     CNAME   server1
 mail         IN     CNAME   server1
 mail2        IN     CNAME   server2
-www          IN     CNAME   server2"""
+www          IN     CNAME   server2""",
+    "sample_txt_1": """$ORIGIN example.com
+$TTL 86400
+@     IN     SOA    dns1.example.com.     hostmaster.example.com. (
+                    2001062501 ; serial
+                    21600      ; refresh after 6 hours
+                    3600       ; retry after 1 hour
+                    604800     ; expire after 1 week
+                    86400 )    ; minimum TTL of 1 day
+
+      IN     NS     dns1.example.com.
+      IN     NS     dns2.example.com.
+
+      IN     MX     10     mail.example.com.
+      IN     MX     20     mail2.example.com.
+
+             IN     A       10.0.1.5
+
+server1      IN     A       10.0.1.5
+server2      IN     A       10.0.1.7
+dns1         IN     A       10.0.1.2
+dns2         IN     A       10.0.1.3
+
+ftp          IN     CNAME   server1
+mail         IN     CNAME   server1
+mail2        IN     CNAME   server2
+www          IN     CNAME   server2
+
+single            IN     TXT     "everything I do"
+singleTTL  100    IN     TXT     "everything I do"
+multi             IN     TXT     "everything I do" "I do for you"
+multiTTL  100     IN     TXT     "everything I do" "I do for you"
+"""
+
 }
 
 zone_file_objects = {
@@ -138,6 +171,46 @@ zone_file_objects = {
     "mx":[
         { "preference": 0, "host": "mail1" },
         { "preference": 10, "host": "mail2" }
+    ]
+  },
+  "sample_txt_1": {
+    "$origin": "MYDOMAIN.COM.",
+    "$ttl": 3600,
+    "soa": {
+        "mname": "NS1.NAMESERVER.NET.",
+        "rname": "HOSTMASTER.MYDOMAIN.COM.",
+        "serial": "4000",
+        "refresh": 3600,
+        "retry": 600,
+        "expire": 604800,
+        "minimum": 86400
+    },
+    "ns": [
+        { "host": "NS1.NAMESERVER.NET." },
+        { "host": "NS2.NAMESERVER.NET." }
+    ],
+    "a": [
+        { "name": "@", "ip": "127.0.0.1" },
+        { "name": "www", "ip": "127.0.0.1" },
+        { "name": "mail", "ip": "127.0.0.1" }
+    ],
+    "aaaa": [
+        { "ip": "::1" },
+        { "name": "mail", "ip": "2001:db8::1" }
+    ],
+    "cname":[
+        { "name": "mail1", "alias": "mail" },
+        { "name": "mail2", "alias": "mail" }
+    ],
+    "mx":[
+        { "preference": 0, "host": "mail1" },
+        { "preference": 10, "host": "mail2" }
+    ],
+    "txt":[
+        {'name' : 'single', 'txt': 'everything I do'},
+        {'name' : 'singleTTL', 'ttl': 100, 'txt': 'everything I do'},
+        {'name' : 'multi', 'txt': ['everything I do', 'I do for you']},
+        {'name' : 'multiTTL', 'ttl': 100, 'txt': ['everything I do', 'I do for you']}
     ]
   }
 }

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -12,6 +12,62 @@ class ZoneFileTests(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_zone_file_parsing_txt(self):
+        zone_file = parse_zone_file(zone_files["sample_txt_1"])
+        self.assertTrue(isinstance(zone_file, dict))
+        self.assertTrue("soa" in zone_file)
+        self.assertTrue("mx" in zone_file)
+        self.assertTrue("ns" in zone_file)
+        self.assertTrue("a" in zone_file)
+        self.assertTrue("cname" in zone_file)
+        self.assertTrue("$ttl" in zone_file)
+        self.assertTrue("$origin" in zone_file)
+        self.assertTrue("txt" in zone_file)
+        self.assertEqual(zone_file["txt"][0]["name"], "single")
+        self.assertEqual(zone_file["txt"][0]["txt"], "everything I do")
+        self.assertEqual(zone_file["txt"][1]["name"], "singleTTL")
+        self.assertEqual(zone_file["txt"][1]["ttl"], 100)
+        self.assertEqual(zone_file["txt"][1]["txt"], "everything I do")
+        self.assertEqual(zone_file["txt"][2]["name"], "multi")
+        self.assertEqual(zone_file["txt"][2]["txt"], 
+                         ["everything I do", "I do for you"])
+        self.assertEqual(zone_file["txt"][3]["name"], "multiTTL")
+        self.assertEqual(zone_file["txt"][3]["ttl"], 100)
+        self.assertEqual(zone_file["txt"][3]["txt"], 
+                         ["everything I do", "I do for you"])
+
+    def test_zone_file_creation_txt(self):
+        json_zone_file = zone_file_objects["sample_txt_1"]
+        zone_file = make_zone_file(json_zone_file)
+        print zone_file
+        self.assertTrue(isinstance(zone_file, (unicode, str)))
+        self.assertTrue("$ORIGIN" in zone_file)
+        self.assertTrue("$TTL" in zone_file)
+        self.assertTrue("@ IN SOA" in zone_file)
+
+        zone_file = parse_zone_file(zone_file)
+        self.assertTrue(isinstance(zone_file, dict))
+        self.assertTrue("soa" in zone_file)
+        self.assertTrue("mx" in zone_file)
+        self.assertTrue("ns" in zone_file)
+        self.assertTrue("a" in zone_file)
+        self.assertTrue("cname" in zone_file)
+        self.assertTrue("$ttl" in zone_file)
+        self.assertTrue("$origin" in zone_file)
+        self.assertTrue("txt" in zone_file)
+        self.assertEqual(zone_file["txt"][0]["name"], "single")
+        self.assertEqual(zone_file["txt"][0]["txt"], "everything I do")
+        self.assertEqual(zone_file["txt"][1]["name"], "singleTTL")
+        self.assertEqual(zone_file["txt"][1]["ttl"], 100)
+        self.assertEqual(zone_file["txt"][1]["txt"], "everything I do")
+        self.assertEqual(zone_file["txt"][2]["name"], "multi")
+        self.assertEqual(zone_file["txt"][2]["txt"], 
+                         ["everything I do", "I do for you"])
+        self.assertEqual(zone_file["txt"][3]["name"], "multiTTL")
+        self.assertEqual(zone_file["txt"][3]["ttl"], 100)
+        self.assertEqual(zone_file["txt"][3]["txt"], 
+                         ["everything I do", "I do for you"])        
+
     def test_zone_file_creation_1(self):
         json_zone_file = zone_file_objects["sample_1"]
         zone_file = make_zone_file(json_zone_file)


### PR DESCRIPTION
Adds support for multiple strings in TXT record.

See the RFC 4408 for TXT records

https://tools.ietf.org/html/rfc4408#section-3.1.3

This bumps the version number on the library. Added tests are included in unit_tests.py. 

TXT records are returned as arrays of strings in the case of multiple strings, and just a string when there is only one. (This ensures backwards compatibility, though admittedly it is a strange interface)

This example has one record with one string, one record with 2 strings.
```
{ ...
    "txt":[
        {'name' : 'single', 'txt': 'one string'},
        {'name' : 'multi', 'txt': ['two', 'strings']},
    ]
}
```